### PR TITLE
ci: upgrade coverage action and add --all-features

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -21,9 +21,9 @@ jobs:
           override: true
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.2
+        uses: actions-rs/tarpaulin@v0.1.3
         with:
-          args: '-- --test-threads 1'
+          args: '--all-features -- --test-threads 1'
           out-type: Xml
 
       - name: Archive code coverage results


### PR DESCRIPTION
This should now include serde tests and fix the issue with insecure GH actions.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/