### PR TITLE
Fix const contex example and revert playground

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 // Nothing of the above _has to_ be that way, so contributions are welcome!
 //
 #![deny(clippy::all, clippy::cargo)]
-#![doc(html_playground_url = "https://play.rust-lang.org/")]
 // Force all constant evaluations to be successful or fail compilation.
 #![forbid(const_err)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ impl<const P: Precision> From<Infallible> for Error<P> {
 /// /// _ => unreachable!(), // not yet available on stable
 /// #   _ => FixedP::zero(), // workaround for panicking on stable
 /// };
-/// const TEN_N_HALF: FixedP<4> = match FixedP::from_units_frac(10, 5) {
+/// const TEN_N_HALF: FixedP<4> = match FixedP::from_units_frac(10, 5000) {
 ///     Ok(n) => n,
 /// /// _ => unreachable!(), // not yet available on stable
 /// #   _ => FixedP::zero(), // workaround for panicking on stable


### PR DESCRIPTION
Revert #4 and fix the const context example to actually have a ten and a half value.